### PR TITLE
feat: added support to Apple managed media source

### DIFF
--- a/packages/modelfusion-experimental/src/browser/MediaSourceAppender.ts
+++ b/packages/modelfusion-experimental/src/browser/MediaSourceAppender.ts
@@ -3,7 +3,7 @@ export class MediaSourceAppender {
   private readonly audioChunks: ArrayBuffer[] = [];
 
   private sourceBuffer?: SourceBuffer;
-  
+
   constructor(type: string) {
     this.mediaSource.addEventListener("sourceopen", async () => {
       this.sourceBuffer = this.mediaSource.addSourceBuffer(type);
@@ -14,15 +14,15 @@ export class MediaSourceAppender {
     });
   }
 
-  private  getMediaSource() {
-      if (window.ManagedMediaSource) {
-          return new ManagedMediaSource();
-      }
-      if (window.MediaSource) {
-          return new MediaSource();
-      }
+  private getMediaSource() {
+    if (window.ManagedMediaSource) {
+      return new ManagedMediaSource();
+    }
+    if (window.MediaSource) {
+      return new MediaSource();
+    }
 
-      throw "No MediaSource API available";
+    throw "No MediaSource API available";
   }
 
   private tryAppendNextChunk() {

--- a/packages/modelfusion-experimental/src/browser/MediaSourceAppender.ts
+++ b/packages/modelfusion-experimental/src/browser/MediaSourceAppender.ts
@@ -1,9 +1,9 @@
 export class MediaSourceAppender {
-  private readonly mediaSource = new MediaSource();
+  private readonly mediaSource = getMediaSource();
   private readonly audioChunks: ArrayBuffer[] = [];
 
   private sourceBuffer?: SourceBuffer;
-
+  
   constructor(type: string) {
     this.mediaSource.addEventListener("sourceopen", async () => {
       this.sourceBuffer = this.mediaSource.addSourceBuffer(type);
@@ -12,6 +12,17 @@ export class MediaSourceAppender {
         this.tryAppendNextChunk();
       });
     });
+  }
+
+  private  getMediaSource() {
+      if (window.ManagedMediaSource) {
+          return new ManagedMediaSource();
+      }
+      if (window.MediaSource) {
+          return new MediaSource();
+      }
+
+      throw "No MediaSource API available";
   }
 
   private tryAppendNextChunk() {


### PR DESCRIPTION
## Sources:
https://bitmovin.com/managed-media-source
https://caniuse.com/?search=media%20source (partially supported, is supported fully only in ipadOS)

## Proposal:
Since iOS doesn't support Media Source Extensions API (MSE), but supports Managed Media Source API (MMS). These changes are intended to make `import { MediaSourceAppender } from "modelfusion-experimental/browser"` to work even in iOS devices.

From the blog _bitmovin_:
"As the MMS supports all methods the “old” MSE does, this is all to get you started (...)”

There are some new events exclusive to MMS that accordingly to the post can unleash the full potential of Apple API, but I did not implement in this PR for the sake of simplicity, since the goal of this PR is to support iOS devices.